### PR TITLE
Make it possible to specify media in webpack_css_tag

### DIFF
--- a/lib/webpack/view_helpers.rb
+++ b/lib/webpack/view_helpers.rb
@@ -10,8 +10,9 @@ module Webpack
     end
 
     # @param name [String]
-    def webpack_css_tag(name)
-      stylesheet_link_tag(webpack_entry_url(name, :css)) if Webpack.config.extract_css
+    # @param media [String]
+    def webpack_css_tag(name, media: "screen")
+      stylesheet_link_tag(webpack_entry_url(name, :css), media: media) if Webpack.config.extract_css
     end
 
     # @param name [String]

--- a/spec/webpack/view_helpers_spec.rb
+++ b/spec/webpack/view_helpers_spec.rb
@@ -106,6 +106,22 @@ RSpec.describe Webpack::ViewHelpers, type: :helper do
       Webpack.config.cdn_host = 'test.io'
       is_expected.to include('http://test.io/foobar/baz.12.css')
     end
+
+    context 'with "screen" media' do
+      subject {  helper.webpack_css_tag(:app, media: 'screen') }
+
+      it 'renders the correct media tag' do
+        is_expected.to include('screen')
+      end
+    end
+
+    context 'with "all" media' do
+      subject {  helper.webpack_css_tag(:app, media: 'all') }
+
+      it 'renders the correct media tag' do
+        is_expected.to include('all')
+      end
+    end
   end
 
   describe '#webpack_static_file_url' do


### PR DESCRIPTION
We need to override media to be able to have print styling in react, this makes us able to do that, @jalet the gemfile was pointing to this repo so making a PR into here 😛 